### PR TITLE
Browse: filters, reset, Showing x of y, a11y and zoom

### DIFF
--- a/404.html
+++ b/404.html
@@ -7,7 +7,7 @@
   <!-- Detect site root from pathname so the same build works at / or /vwad-new/ or any subpath. -->
   <script>(function(){var path=window.location.pathname||'/';var basePath;if(path.match(/\/app\/?$/)){basePath=path.replace(/\/app\/?$/,'').replace(/\/$/,'')||'';}else if(path.indexOf('/app/')!==-1&&path.indexOf('app.html')===-1){basePath=path.split('/app/')[0].replace(/\/$/,'')||'';}else{basePath=path.endsWith('/')?path.slice(0,-1):path.replace(/\/[^/]*$/,'');}window.VWAD_BASE=(basePath===''||basePath==='/')?'':basePath;})();</script>
   <script>(function(){var t;try{t=localStorage.getItem('vwad-theme');}catch(e){}var effective;if(!t||t==='system'){effective=window.matchMedia&&matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light';}else{effective=t;}document.documentElement.setAttribute('data-theme',effective);})();</script>
-  <link rel="stylesheet" href="css/site.css?v=19">
+  <link rel="stylesheet" href="css/site.css?v=1">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&family=Poppins:wght@400;500;600;700&display=swap&v=10" rel="stylesheet">
@@ -67,8 +67,8 @@
     </div>
   </footer>
 
-  <script src="js/app.js?v=9"></script>
-  <script src="js/theme.js?v=3"></script>
-  <script src="js/app-viewer.js?v=10"></script>
+  <script src="js/app.js?v=1"></script>
+  <script src="js/theme.js?v=1"></script>
+  <script src="js/app-viewer.js?v=1"></script>
 </body>
 </html>

--- a/app/index.html
+++ b/app/index.html
@@ -7,7 +7,7 @@
   <base href="../">
   <script>(function(){var path=window.location.pathname||'/';var basePath;if(path.match(/\/app\/?$/)){basePath=path.replace(/\/app\/?$/,'').replace(/\/$/,'')||'';}else if(path.indexOf('/app/')!==-1&&path.indexOf('app.html')===-1){basePath=path.split('/app/')[0].replace(/\/$/,'')||'';}else{basePath=path.endsWith('/')?path.slice(0,-1):path.replace(/\/[^/]*$/,'');}window.VWAD_BASE=(basePath===''||basePath==='/')?'':basePath;})();</script>
   <script>(function(){var t;try{t=localStorage.getItem('vwad-theme');}catch(e){}var effective;if(!t||t==='system'){effective=window.matchMedia&&matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light';}else{effective=t;}document.documentElement.setAttribute('data-theme',effective);})();</script>
-  <link rel="stylesheet" href="css/site.css?v=19">
+  <link rel="stylesheet" href="css/site.css?v=1">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&family=Poppins:wght@400;500;600;700&display=swap&v=10" rel="stylesheet">
@@ -63,8 +63,8 @@
     </div>
   </footer>
 
-  <script src="js/app.js?v=10"></script>
-  <script src="js/theme.js?v=3"></script>
+  <script src="js/app.js?v=1"></script>
+  <script src="js/theme.js?v=1"></script>
   <script>
     (function () {
       function getSlug() {
@@ -76,7 +76,7 @@
       window.VWAD.getPathSlug = function () { return getSlug(); };
     })();
   </script>
-  <script src="js/app-viewer.js?v=10"></script>
+  <script src="js/app-viewer.js?v=1"></script>
   <script>
     (function () {
       window.addEventListener('hashchange', function () {

--- a/css/site.css
+++ b/css/site.css
@@ -86,19 +86,20 @@
 }
 
 html {
-  font-size: 16px;
+  font-size: 100%;
   scroll-behavior: smooth;
 }
 
 body {
   margin: 0;
   font-family: var(--font-body);
-  font-size: 16px;
+  font-size: 1rem;
   font-weight: 400;
-  line-height: 24px;
-  letter-spacing: -0.32px; /* body-16r from community */
+  line-height: 1.5;
+  letter-spacing: -0.02em; /* body-16r from community; em so it scales with zoom */
   background: var(--bg-page);
   color: var(--text);
+  overflow-wrap: break-word;
 }
 
 /* Skip link - visible on focus for keyboard users */
@@ -167,6 +168,7 @@ h1, h2, h3, h4, h5, h6 {
   max-width: 960px;
   margin: 0 auto;
   padding: 0 1.25rem;
+  min-width: 0; /* allow shrink in flex contexts for reflow/zoom */
 }
 
 .container-wide {
@@ -221,9 +223,11 @@ h1, h2, h3, h4, h5, h6 {
 .site-header .container-wide {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   min-height: 5rem;
+  gap: 0.5rem;
 }
 
 /* Logo: OWASP header SVG - h-10 (2.5rem), fixed width, shrink-0, hover opacity 90% (community) */
@@ -1132,11 +1136,13 @@ h1, h2, h3, h4, h5, h6 {
   flex-wrap: wrap;
   gap: 0.75rem;
   align-items: center;
+  min-width: 0;
 }
 
 .search-input {
-  flex: 1;
-  min-width: 200px;
+  flex: 1 1 12rem;
+  min-width: 0;
+  max-width: 100%;
   padding: 0.5rem 0.75rem;
   font: inherit;
   color: var(--text);
@@ -1163,7 +1169,9 @@ h1, h2, h3, h4, h5, h6 {
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  min-width: 140px;
+  min-width: 0;
+  flex: 1 1 10rem;
+  max-width: 100%;
 }
 
 .filter-select:focus,
@@ -1176,9 +1184,51 @@ h1, h2, h3, h4, h5, h6 {
   margin: 0.5rem 0 0;
 }
 
+.result-count-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  margin: 0.5rem 0 0;
+}
+
+.result-count-row .result-count {
+  margin: 0;
+}
+
+.search-reset-btn {
+  margin: 0;
+  padding: 0.25rem 0.5rem;
+  font: inherit;
+  font-size: 0.875rem;
+  color: var(--link);
+  background: none;
+  border: none;
+  border-radius: var(--radius);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.search-reset-btn:hover:not(:disabled),
+.search-reset-btn:focus-visible:not(:disabled) {
+  color: var(--link-hover);
+}
+
+.search-reset-btn:disabled {
+  cursor: default;
+  opacity: 0.5;
+  text-decoration: none;
+}
+
+.search-reset-btn:focus-visible {
+  outline: 2px solid var(--focus-ring, #0d6efd);
+  outline-offset: 2px;
+}
+
 /* Table */
 .table-scroll-outer {
   position: relative;
+  max-width: 100%;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--bg-card);
@@ -1189,6 +1239,7 @@ h1, h2, h3, h4, h5, h6 {
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   border-radius: var(--radius);
+  min-width: 0;
 }
 
 /* Left/right edge fades on small viewports: show fade where more content can be revealed by scrolling.
@@ -1264,6 +1315,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .apps-table th {
+  font-size: 1rem;
   font-weight: 600;
   font-family: var(--font-heading);
   color: var(--text-muted);
@@ -1326,8 +1378,48 @@ h1, h2, h3, h4, h5, h6 {
   text-decoration: underline;
 }
 
+.apps-table .author-match {
+  display: block;
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  margin-top: 0.15em;
+}
+
 .apps-table .pill {
   margin-right: 0.25rem;
+}
+
+/* Clickable filter pills: button reset + pointer + focus-visible */
+.apps-table button.pill {
+  cursor: pointer;
+  font: inherit;
+  margin: 0 0.25rem 0 0;
+  -webkit-appearance: none;
+  appearance: none;
+}
+.apps-table button.pill:hover {
+  opacity: 0.9;
+}
+.apps-table button.pill:focus-visible {
+  outline: 2px solid var(--focus-ring, #0d6efd);
+  outline-offset: 2px;
+}
+.apps-table button.pill.pill-category {
+  border-style: dashed;
+  border-width: 1px;
+  border-color: #5c7c99;
+  background: #e8eef4;
+  color: #2c3e50;
+}
+[data-theme="dark"] .apps-table button.pill.pill-category {
+  border-color: #6b8fb3;
+  background: #2a3544;
+  color: #b8d4e8;
+}
+[data-theme="dark"] .apps-table button.pill:not([class*="pill-updated"]):not(.pill-category) {
+  background: #3d424a;
+  color: #e6e8eb;
+  border-color: #5d636b;
 }
 
 /* Stars column: monospace + right-align so digits line up (Poppins tabular-nums not sufficient) */
@@ -1430,7 +1522,8 @@ h1, h2, h3, h4, h5, h6 {
 
 .app-detail-row .label {
   color: var(--text-muted);
-  font-size: 0.9rem;
+  font-size: 1rem;
+  font-weight: 600;
   min-width: 7rem;
 }
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>OWASP Vulnerable Web Applications Directory</title>
   <script>(function(){var path=window.location.pathname||'/';var basePath;if(path.match(/\/app\/?$/)){basePath=path.replace(/\/app\/?$/,'').replace(/\/$/,'')||'';}else if(path.indexOf('/app/')!==-1&&path.indexOf('app.html')===-1){basePath=path.split('/app/')[0].replace(/\/$/,'')||'';}else{basePath=path.endsWith('/')?path.slice(0,-1):path.replace(/\/[^/]*$/,'');}window.VWAD_BASE=(basePath===''||basePath==='/')?'':basePath;})();</script>
   <script>(function(){var t;try{t=localStorage.getItem('vwad-theme');}catch(e){}var effective;if(!t||t==='system'){effective=window.matchMedia&&matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light';}else{effective=t;}document.documentElement.setAttribute('data-theme',effective);})();</script>
-  <link rel="stylesheet" href="css/site.css?v=19">
+  <link rel="stylesheet" href="css/site.css?v=1">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&family=Poppins:wght@400;500;600;700&display=swap&v=10" rel="stylesheet">
@@ -61,11 +61,11 @@
     <section id="browse" class="section">
       <div class="container">
         <h2>Browse &amp; search</h2>
-        <p class="section-desc">Search by name, author, technology, notes, or collection. Filter by collection or technology.</p>
+        <p class="section-desc">Search by name or author. Filter by collection, technology, or category.</p>
         <div class="search-controls">
           <div class="search-row">
             <label for="search-input" class="sr-only">Search</label>
-            <input type="search" id="search-input" class="search-input" placeholder="Search name, author, technology, notes…" autocomplete="off">
+            <input type="search" id="search-input" class="search-input" placeholder="Search name, author…" autocomplete="off">
             <label for="filter-collection" class="sr-only">Collection</label>
             <select id="filter-collection" class="filter-select" aria-label="Filter by collection">
               <option value="">All collections</option>
@@ -77,9 +77,23 @@
             </select>
             <label for="filter-technology" class="sr-only">Technology</label>
             <input type="text" id="filter-technology" class="filter-tech" placeholder="Technology (e.g. PHP, Docker)" list="tech-suggestions">
+            <label for="filter-category" class="sr-only">Category</label>
+            <select id="filter-category" class="filter-select" aria-label="Filter by category">
+              <option value="">All categories</option>
+              <option value="ctf">CTF</option>
+              <option value="code-review">Code review</option>
+              <option value="single-player">Single-player</option>
+              <option value="multi-player">Multi-player</option>
+              <option value="guided-lessons">Guided lessons</option>
+              <option value="free-form">Free-form</option>
+              <option value="scanner-test">Scanner test</option>
+            </select>
             <datalist id="tech-suggestions"></datalist>
           </div>
-          <p id="result-count" class="result-count muted">-</p>
+          <div class="result-count-row">
+            <p id="result-count" class="result-count muted" aria-live="polite">-</p>
+            <button type="button" id="search-reset" class="search-reset-btn" aria-label="Clear all search and filters" disabled>Reset</button>
+          </div>
         </div>
         <div id="browse-results" class="browse-results">
           <p class="muted">Loading…</p>
@@ -117,9 +131,9 @@
     </div>
   </footer>
 
-  <script src="js/app.js?v=9"></script>
-  <script src="js/theme.js?v=3"></script>
-  <script src="js/home.js?v=15"></script>
+  <script src="js/app.js?v=1"></script>
+  <script src="js/theme.js?v=1"></script>
+  <script src="js/home.js?v=1"></script>
   <script>
     (function () {
       function escapeHtml(s) {

--- a/js/app.js
+++ b/js/app.js
@@ -57,7 +57,7 @@
     query = (query || '').toLowerCase().trim();
     filters = filters || {};
     return collectionPromise.then(function (list) {
-      return list.filter(function (app) {
+      var filtered = list.filter(function (app) {
         if (filters.collection && filters.collection.length) {
           var hasCollection = (app.collection || []).some(function (c) {
             return filters.collection.indexOf(c) !== -1;
@@ -73,17 +73,23 @@
           });
           if (!hasTech) return false;
         }
+        if (filters.categories && filters.categories.length) {
+          var appCats = (app.categories || []).map(function (c) {
+            return c.toLowerCase();
+          });
+          var hasCategory = filters.categories.some(function (cat) {
+            return appCats.indexOf(cat.toLowerCase()) !== -1;
+          });
+          if (!hasCategory) return false;
+        }
         if (!query) return true;
         var searchable = [
           app.name,
-          app.author,
-          app.notes,
-          (app.technology || []).join(' '),
-          (app.categories || []).join(' '),
-          (app.collection || []).join(' ')
+          app.author
         ].join(' ').toLowerCase();
         return searchable.indexOf(query) !== -1;
       });
+      return { apps: filtered, total: list.length };
     });
   }
 


### PR DESCRIPTION
- Clickable filter pills: collection/tech/category pills set filter,  clear others, and run search.
- Search: first field matches name and author only; show "Author: name"  when query matches author.
- Result count: "Showing x of y applications"; searchApps returns  { apps, total }.
- Reset button clears search and filters; disabled when no filters;  state updates at start of runSearch().
- Category filter dropdown added and wired to filters.categories.
- A11y/zoom: relative units, min-width: 0, flexible search row and  header wrap; no maximum-scale; table th 1rem, detail labels 1rem/600.
- Reset cache busters to v=1 in all HTML.