### PR TITLE
Scout WF tweaks

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -9,6 +9,6 @@ Workflows in this directory:
 - **Update GitHub Statistics** (`update-stats.yml`) – Weekly; updates stars and last-contribution dates in `collection.json`, and `data/archived_repos.json` when it detects archived repos (may create an issue).
 - **Update GitHub Contributors** (`update-contributors.yml`) – Weekly; writes `data/contributors.json` and commits when changed.
 - **Link Checker** (`link-checker.yml`) – Manual; validates app and reference URLs in `collection.json`.
-- **Repository Scout** (`repo-scout.yml`) – Weekly; runs `scout.py` to discover new vulnerable-app repos and opens an issue with findings.
+- **Repository Scout** (`repo-scout.yml`) – Weekly; runs `scout.py` to discover new vulnerable-app repos, tracks suggestions in `data/scout_suggested.json`, and opens an issue with findings when appropriate.
 
 See [scripts/README.md](scripts/README.md) for script details.

--- a/.github/workflows/repo-scout.yml
+++ b/.github/workflows/repo-scout.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   issues: write
 
 jobs:
@@ -33,6 +33,22 @@ jobs:
         run: |
           python .github/workflows/scripts/scout.py
 
+      - name: Check for scout suggested list changes
+        id: git-check
+        run: |
+          if [ -n "$(git status --short data/scout_suggested.json 2>/dev/null)" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push scout suggested list
+        if: steps.git-check.outputs.changed == 'true'
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add data/scout_suggested.json
+          git commit -m "Track scout-suggested repositories [automated]"
+          git push
+
       - name: Create Issue with Findings
         if: success()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
@@ -49,6 +65,18 @@ jobs:
 
             if (results.repositories.length === 0) {
               console.log('No new repositories found');
+              return;
+            }
+
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'new app',
+            });
+            const openScoutIssue = openIssues.find((issue) => issue.title.includes('Scout Report'));
+            if (openScoutIssue) {
+              console.log(`Open scout issue #${openScoutIssue.number} exists; skipping new issue`);
               return;
             }
 

--- a/.github/workflows/scripts/README.md
+++ b/.github/workflows/scripts/README.md
@@ -111,7 +111,7 @@ If `output_file` is omitted, writes to `data/contributors.json`.
 
 ### scout.py
 
-Discovers GitHub repositories that may be candidates for the vulnerable web applications directory (e.g. via search). Reads existing repos from `data/collection.json` to avoid duplicates. Outputs `scout-results.json` and `scout-issue-body.md` for the **Repository Scout** workflow, which creates an issue with label `new app` when new repositories are found.
+Discovers GitHub repositories that may be candidates for the vulnerable web applications directory (e.g. via search). Skips repos already in `data/collection.json` or `data/scout_suggested.json` (persistent list of previously reported suggestions; same shape as `archived_repos.json`: `url`, `name`, `date`, `notes`). New suggestions are merged into `scout_suggested.json` for the workflow to commit. Outputs `scout-results.json` and `scout-issue-body.md` for the **Repository Scout** workflow, which creates an issue with label `new app` when new repositories are found and no open scout issue already exists.
 
 **Usage:**
 ```bash
@@ -220,7 +220,7 @@ These scripts are automatically executed by GitHub Actions workflows:
 - `update-sourceforge-stats.yml`: Runs `update_sourceforge_stats.py` weekly (Sundays 04:00 UTC, a few hours after GitHub stats); updates `last_contributed` for SourceForge-only entries in `data/collection.json` and commits when changed.
 - `link-checker.yml`: Runs `check_links.py` on manual trigger to validate all app and reference URLs.
 - `update-contributors.yml`: Runs `update_contributors.py` weekly to update `data/contributors.json`; commits and pushes when the file changes.
-- `repo-scout.yml`: Runs `scout.py` weekly (Mondays 09:00 UTC); creates an issue with new repository findings (label `new app`).
+- `repo-scout.yml`: Runs `scout.py` weekly (Mondays 09:00 UTC); commits `data/scout_suggested.json` when new repos are found; creates an issue with new repository findings (label `new app`) if no open scout issue exists.
 
 The validation results from `validate.yml` are:
 

--- a/.github/workflows/scripts/scout.py
+++ b/.github/workflows/scripts/scout.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 import os
 import json
-import re
 from datetime import datetime
 from urllib.parse import urlparse
 from github import Github
+
+SCOUT_SUGGESTED_LIST_PATH = "data/scout_suggested.json"
+
 
 def extract_github_repo(url):
     """Extract normalized owner/repo from a GitHub URL.
@@ -20,16 +22,13 @@ def extract_github_repo(url):
         if parsed.netloc != 'github.com':
             return None
 
-        # Get path and split into segments
         path = parsed.path.strip('/')
         if not path:
             return None
 
-        # Remove .git suffix if present
         if path.endswith('.git'):
             path = path[:-4]
 
-        # Split path and get first two segments (owner/repo)
         segments = path.split('/')
         if len(segments) >= 2:
             return f"{segments[0]}/{segments[1]}".lower()
@@ -38,31 +37,91 @@ def extract_github_repo(url):
     except Exception:
         return None
 
-def load_existing_repos():
-    """Load existing GitHub repos from collection.json to avoid duplicates"""
-    existing = set()
+
+def load_collection_repos():
+    """Load GitHub repos already listed in collection.json."""
+    repos = set()
     try:
         if os.path.exists('data/collection.json'):
-            with open('data/collection.json', 'r') as f:
+            with open('data/collection.json', 'r', encoding='utf-8') as f:
                 data = json.load(f)
                 for item in data:
-                    # Check main URL
                     url = item.get('url', '')
                     repo = extract_github_repo(url)
                     if repo:
-                        existing.add(repo)
+                        repos.add(repo)
 
-                    # Check references array for GitHub URLs
                     if 'references' in item and isinstance(item['references'], list):
                         for ref in item['references']:
                             if isinstance(ref, dict) and 'url' in ref:
-                                ref_url = ref['url']
-                                repo = extract_github_repo(ref_url)
+                                repo = extract_github_repo(ref['url'])
                                 if repo:
-                                    existing.add(repo)
+                                    repos.add(repo)
     except Exception as e:
         print(f"Warning: Could not load collection.json: {e}")
-    return existing
+    return repos
+
+
+def load_scout_suggested_list():
+    """
+    Load the persistent scout-suggested list from data/scout_suggested.json.
+    Repos already in this list are not reported again.
+    """
+    if not os.path.exists(SCOUT_SUGGESTED_LIST_PATH):
+        return [], set()
+
+    try:
+        with open(SCOUT_SUGGESTED_LIST_PATH, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, IOError) as e:
+        print(f"Warning: Failed to load {SCOUT_SUGGESTED_LIST_PATH}: {e}")
+        return [], set()
+
+    if not isinstance(data, list):
+        print(f"Warning: {SCOUT_SUGGESTED_LIST_PATH} should be a JSON array of objects")
+        return [], set()
+
+    entries = []
+    repos = set()
+    for item in data:
+        if not isinstance(item, dict) or not item.get('url'):
+            continue
+        url = (item.get('url') or '').strip()
+        entries.append({
+            "url": url,
+            "name": item.get("name", url),
+            "date": item.get("date", ""),
+            "notes": item.get("notes", ""),
+        })
+        repo = extract_github_repo(url)
+        if repo:
+            repos.add(repo)
+
+    return entries, repos
+
+
+def save_scout_suggested_list(existing_entries, new_entries):
+    """Merge new scout suggestions into data/scout_suggested.json by URL."""
+    seen = {(entry.get("url") or "").strip().lower() for entry in existing_entries}
+    merged = list(existing_entries)
+    for entry in new_entries:
+        url = (entry.get("url") or "").strip()
+        if url and url.lower() not in seen:
+            merged.append({
+                "url": url,
+                "name": entry.get("name", url),
+                "date": entry.get("date", ""),
+                "notes": entry.get("notes", ""),
+            })
+            seen.add(url.lower())
+
+    try:
+        with open(SCOUT_SUGGESTED_LIST_PATH, 'w', encoding='utf-8') as f:
+            json.dump(merged, f, indent=2, ensure_ascii=False)
+            f.write('\n')
+    except IOError as e:
+        print(f"Warning: Failed to write {SCOUT_SUGGESTED_LIST_PATH}: {e}")
+
 
 def main():
     token = os.environ.get('GITHUB_TOKEN')
@@ -72,28 +131,34 @@ def main():
 
     print("Starting scout...")
 
-    # Load existing repos to prevent duplicates
-    existing = load_existing_repos()
-    print(f"Loaded {len(existing)} existing repositories from collection")
+    collection_repos = load_collection_repos()
+    suggested_entries, suggested_repos = load_scout_suggested_list()
+    known = collection_repos | suggested_repos
+
+    print(f"Loaded {len(collection_repos)} repositories from collection")
+    print(f"Loaded {len(suggested_repos)} previously suggested repositories")
 
     gh = Github(token)
     found = []
-    skipped = 0
+    skipped_collection = 0
+    skipped_suggested = 0
 
-    # Search for vulnerable apps
     queries = ["intentionally vulnerable", "deliberately vulnerable web"]
     for query in queries:
         print(f"Searching: {query}")
         try:
-            # Build query with filters: stars, fork, archived
             search_query = f"{query} stars:>=10 fork:false archived:false"
             results = gh.search_repositories(query=search_query, sort='stars', order='desc')
 
             for repo in list(results)[:5]:
-                # Skip if already in collection
-                if repo.full_name.lower() in existing:
+                repo_key = repo.full_name.lower()
+                if repo_key in collection_repos:
                     print(f"  Skipping {repo.name} (already in collection)")
-                    skipped += 1
+                    skipped_collection += 1
+                    continue
+                if repo_key in known:
+                    print(f"  Skipping {repo.name} (previously suggested)")
+                    skipped_suggested += 1
                     continue
 
                 found.append({
@@ -104,36 +169,40 @@ def main():
                     'language': repo.language or 'Unknown',
                     'full_name': repo.full_name
                 })
+                known.add(repo_key)
                 print(f"  Found: {repo.name} ({repo.stargazers_count} stars)")
         except Exception as e:
             print(f"Error searching '{query}': {e}")
 
-    # Check if we found any new repositories
     if len(found) == 0:
-        print(f"Done!")
+        print("Done!")
         print(f"  New repos found: {len(found)}")
-        print(f"  Duplicates skipped: {skipped}")
-        print(f"  Existing in collection: {len(existing)}")
+        print(f"  Skipped (in collection): {skipped_collection}")
+        print(f"  Skipped (previously suggested): {skipped_suggested}")
         print("  No issue will be created (no new apps found)")
         return 0
 
-    # Save results only if we have new repositories
     date = datetime.now().strftime('%Y-%m-%d')
-    with open('scout-results.json', 'w') as f:
+    save_scout_suggested_list(
+        suggested_entries,
+        [{"url": r['url'], "name": r['name'], "date": date, "notes": ""} for r in found],
+    )
+
+    with open('scout-results.json', 'w', encoding='utf-8') as f:
         json.dump({
             'scan_date': date,
             'total_found': len(found),
-            'total_skipped': skipped,
-            'existing_in_collection': len(existing),
+            'skipped_collection': skipped_collection,
+            'skipped_suggested': skipped_suggested,
             'repositories': found
         }, f, indent=2)
 
-    # Create issue body
-    body = f"## 🔍 Scout Report - {date}\n\n"
-    body += f"**Summary:**\n"
+    body = "<details>\n"
+    body += "<summary>### Summary</summary>\n\n"
     body += f"- New repositories found: {len(found)}\n"
-    body += f"- Already in collection (skipped): {skipped}\n"
-    body += f"- Total existing in collection: {len(existing)}\n\n"
+    body += f"- Already in collection (skipped): {skipped_collection}\n"
+    body += f"- Previously suggested (skipped): {skipped_suggested}\n\n"
+    body += "</details>\n\n"
     body += "---\n\n"
 
     body += "### 🆕 New Repositories\n\n"
@@ -156,18 +225,18 @@ def main():
         }, indent=2)
         body += "\n```\n\n"
         body += "</details>\n\n"
-        body += "---\n\n"
+        if i < len(found):
+            body += "---\n\n"
 
-    body += "\n*🤖 This issue was created automatically by the Repository Scout GitHub Action*\n"
-
-    with open('scout-issue-body.md', 'w') as f:
+    with open('scout-issue-body.md', 'w', encoding='utf-8') as f:
         f.write(body)
 
-    print(f"\nDone!")
+    print("\nDone!")
     print(f"  New repos found: {len(found)}")
-    print(f"  Duplicates skipped: {skipped}")
-    print(f"  Existing in collection: {len(existing)}")
+    print(f"  Skipped (in collection): {skipped_collection}")
+    print(f"  Skipped (previously suggested): {skipped_suggested}")
     return 0
+
 
 if __name__ == '__main__':
     exit(main())

--- a/data/scout_suggested.json
+++ b/data/scout_suggested.json
@@ -1,0 +1,8 @@
+[
+  {
+    "url": "https://github.com/afsh4ck/HackLabs",
+    "name": "HackLabs",
+    "date": "2026-06-22",
+    "notes": "Reported in scout issue #84"
+  }
+]


### PR DESCRIPTION
- Scout stop re-report same repo every Monday
- data/scout_suggested.json — same trick as archived_repos.json; seed afsh4ck/HackLabs from #84
- Skip if in collection, already suggested, or same run hit twice
- Workflow commits suggested list; no new issue if open Scout Report exists
- Issue body: collapsible ### Summary, drop duplicate title + bot footer