### PR TITLE
Add Jackpot, a browser lab for the OWASP LLM Top 10

### DIFF
--- a/data/collection.json
+++ b/data/collection.json
@@ -2512,6 +2512,32 @@
 		]
 	},
 	{
+		"url": "https://hego.red/jackpot",
+		"name": "Jackpot",
+		"slug": "jackpot",
+		"collection": [
+			"online"
+		],
+		"categories": [
+			"ctf",
+			"single-player"
+		],
+		"technology": [
+			"AI",
+			"LLM",
+			"Prompt Injection"
+		],
+		"references": [
+			{
+				"name": "live",
+				"url": "https://hego.red/jackpot"
+			}
+		],
+		"author": "hego",
+		"description": "A ten floor casino where every floor is a deliberately broken AI character, one per category of the OWASP Top 10 for LLM Applications. Covers prompt injection, system prompt leakage, RAG poisoning, excessive agency and improper output handling. Runs in the browser, no signup.",
+		"notes": "No signup or account needed. Progress is kept in the browser's local storage; use the in-page Clear all progress button to reset."
+	},
+	{
 		"url": "https://github.com/Sjord/jwtdemo/",
 		"name": "jwtdemo",
 		"slug": "jwtdemo",


### PR DESCRIPTION
Moved from OWASP/www-project-vulnerable-web-applications-directory#275 as @kingthorin asked. Thanks for the pointer, and sorry for the noise on the wrong repo.

Adds **Jackpot** (https://hego.red/jackpot), an online lab where each of ten floors is a deliberately vulnerable AI character mapped to one category of the OWASP Top 10 for LLM Applications: prompt injection, sensitive information disclosure, supply chain, data and model poisoning, improper output handling, excessive agency, system prompt leakage, vector and embedding weaknesses, misinformation, unbounded consumption.

- `online`, no signup, no accounts, nothing stored server side
- `ctf`, `single-player`
- The characters are a deterministic simulation rather than a live model, so it is free to run, needs no API key, and behaves identically for every visitor
- Win conditions, trigger lists and the secrets live server side only, so the answers are not in the page
- Every floor wins on a fact (the secret left the model, the tool fired), never on a guess about intent

Per CONTRIBUTING: one entry added to `data/collection.json`, tab indented, sorted case insensitively by `name` (between `InsecureBankv2` and `jwtdemo`), written back with `ensure_ascii=False` and a trailing newline. Validated locally against `schema.json` with `jsonschema` - 211 entries, no unknown keys, all four required fields present. Nothing else in the file is touched.

Disclosure: I am the author.
