### PR TITLE
Add Damn Vulnerable Application Security Platform (DVASP)

### DIFF
--- a/data/collection.json
+++ b/data/collection.json
@@ -887,6 +887,40 @@
 		]
 	},
 	{
+		"url": "https://github.com/rek7/DVASP",
+		"name": "Damn Vulnerable Application Security Platform (DVASP)",
+		"slug": "damn-vulnerable-application-security-platform-dvasp",
+		"collection": [
+			"online",
+			"offline",
+			"container",
+			"platform"
+		],
+		"technology": [
+			"Python",
+			"TypeScript",
+			"Docker"
+		],
+		"references": [
+			{
+				"name": "announcement",
+				"url": "https://blog.raphael.karger.is/articles/2026-08/bh-2026"
+			}
+		],
+		"author": "Raphael Karger",
+		"description": "A local application security platform for repository assessment workflows across security tools, SCA, IaC scanning, container review, and secrets governance. Used to showcase attacks against hosted code security vendors.",
+		"notes": "Run locally with `docker compose up`; operator UI at http://127.0.0.1:8080 and API at http://127.0.0.1:8000. Local-first: published service ports bind to 127.0.0.1 in the default compose configuration. Seeded credentials are synthetic watermarked values only.",
+		"badge": "rek7/DVASP",
+		"categories": [
+			"ctf",
+			"code-review",
+			"single-player",
+			"multi-player",
+			"free-form",
+			"scanner-test"
+		]
+	},
+	{
 		"url": "https://github.com/rewanthtammana/Damn-Vulnerable-Bank",
 		"name": "Damn Vulnerable Bank",
 		"slug": "damn-vulnerable-bank",


### PR DESCRIPTION
Adds **Damn Vulnerable Application Security Platform (DVASP)** to `data/collection.json`, per the submission in #99.

Closes #99

### Entry summary

| Field | Value |
|---|---|
| Name | Damn Vulnerable Application Security Platform (DVASP) |
| URL | https://github.com/rek7/DVASP |
| Author | Raphael Karger |
| Collection | `online`, `offline`, `container`, `platform` |
| Categories | `ctf`, `code-review`, `single-player`, `multi-player`, `free-form`, `scanner-test` |
| Technology | Python, TypeScript, Docker |

DVASP is an intentionally vulnerable application security platform that presents a product-style AppSec operator workspace — repository assessment runs, SCA/dependency analysis, IaC scanning, container review, and secret scanning — used to demonstrate attacks against hosted code security vendors. It ships a `docker compose` stack with a React/TypeScript operator UI and a FastAPI backend, so it is a vulnerable target rather than a scanning tool.

### Notes on the data

- Description and technology are taken from the project's own README and the submission in #99.
- `badge` is set to `rek7/DVASP` so the scheduled `update-stats` workflow can populate `stars` and `last_contributed`; those fields are intentionally omitted here rather than hand-written.
- `notes` contains operational information only (compose command, local service URLs, the local-first `127.0.0.1` port binding, and the fact that seeded credentials are synthetic watermarked values), per CONTRIBUTING.
- `container` is included because the project is deployed via Docker Compose, per the contributing guidance on container/VM-based entries.
- The `announcement` reference points at the accompanying write-up: https://blog.raphael.karger.is/articles/2026-08/bh-2026

### Validation

Ran the same scripts CI uses, all passing against the modified file:

- `check_schema.py` — `SUCCESS: All entries conform to the schema`
- `check_ordering.py` — `SUCCESS: All entries are ordered alphabetically by 'name' field`
- `check_editorconfig.py` — `SUCCESS: File adheres to .editorconfig rules`

The entry sorts between `Damn Vulnerable Application Scanner (DVAS)` and `Damn Vulnerable Bank`; the diff is additive only and touches no other entry.

---
Submitted from @r0path, an alternate account of @rek7 who filed #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)