### PR TITLE
Add InjectArena (攻心) — self-hostable LLM prompt injection CTF

### DIFF
--- a/data/collection.json
+++ b/data/collection.json
@@ -2555,6 +2555,46 @@
 		]
 	},
 	{
+		"url": "https://github.com/Croesus-K/InjectArena",
+		"name": "InjectArena (攻心)",
+		"slug": "injectarena",
+		"collection": [
+			"offline",
+			"container"
+		],
+		"categories": [
+			"ctf",
+			"single-player",
+			"guided-lessons"
+		],
+		"technology": [
+			"Node.js",
+			"Fastify",
+			"SQLite",
+			"Docker",
+			"LLM"
+		],
+		"references": [
+			{
+				"name": "guide",
+				"url": "https://github.com/Croesus-K/InjectArena#readme"
+			},
+			{
+				"name": "download",
+				"url": "https://github.com/Croesus-K/InjectArena/releases"
+			},
+			{
+				"name": "docker",
+				"url": "https://ghcr.io/croesus-k/injectarena"
+			}
+		],
+		"author": "Croesus-K",
+		"description": "Self-hostable Chinese-language LLM prompt injection CTF: five levels covering direct injection, data exfiltration, guarded prompts, indirect injection (RAG poisoning) and tool abuse, with dual attack/defense scoring, leaderboards and post-breach lessons mapped to the OWASP LLM Top 10 (2025). BYOK via any OpenAI-compatible API.",
+		"notes": "Run: docker compose up -d (image: ghcr.io/croesus-k/injectarena) or npm start; requires Node.js >= 22.13 for node:sqlite. BYOK: the operator supplies an OpenAI-compatible API key server-side. Warning: do not deploy publicly with a paid key. Judging is deterministic code — no LLM-as-judge.",
+		"badge": "Croesus-K/InjectArena",
+		"last_contributed": "2026-08-31T08:00:00Z"
+	},
+	{
 		"url": "https://github.com/omerlh/insecure-deserialisation-net-poc",
 		"name": "insecure-deserialisation-net-poc",
 		"slug": "insecure-deserialisation-net-poc",


### PR DESCRIPTION
Adds [InjectArena (攻心)](https://github.com/Croesus-K/InjectArena) to the directory.

Self-hostable Chinese-language LLM prompt injection CTF with five levels: direct injection, data exfiltration, guarded prompts (keyword filtering + hardened persona), indirect injection (RAG poisoning via a zero-dependency deterministic retriever) and tool abuse (simulated `send_report` tool; judging extends to tool-call arguments).

- Dual attack/defense scoring: deterministic judge (never LLM-as-judge); per-level defense slots scored against a 100-payload aligned corpus (block/leak/false-positive rates) — defense is regression-testable.
- Post-breach lessons mapped to the OWASP LLM Top 10 (2025).
- MIT; runs via `docker compose up -d` (image: ghcr.io/croesus-k/injectarena) or `npm start` (Node.js >= 22.13, built-in node:sqlite).

Entry follows schema.json (slug included); data/collection.json keeps tab indentation and case-insensitive name sorting — 35-line insertion only.

(First submission to the new home — an earlier attempt on the old repository was redirected here by @kingthorin.)